### PR TITLE
Fix log formatter on Windows

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -5,6 +5,7 @@ package logger
 import (
 	"bytes"
 	"fmt"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"

--- a/formatter.go
+++ b/formatter.go
@@ -37,6 +37,8 @@ const defaultTimestampFormat = time.RFC3339
 
 // Format renders a single log entry
 func (f *textFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	var isColored bool
+
 	prefixFieldClashes(entry.Data)
 
 	keys := make([]string, 0, len(entry.Data))
@@ -55,7 +57,11 @@ func (f *textFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 
 	f.Do(func() { f.init(entry) })
 
-	isColored := (f.ForceColors || f.isTerminal)
+	if runtime.GOOS == "windows" {
+		isColored = f.isTerminal
+	} else {
+		isColored = (f.ForceColors || f.isTerminal)
+	}
 
 	if isColored {
 		f.printColored(b, entry, keys)
@@ -70,11 +76,18 @@ func (f *textFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 		}
 	}
 
+	if runtime.GOOS == "windows" {
+		b.WriteByte('\r')
+	}
+
 	b.WriteByte('\n')
 	return b.Bytes(), nil
 }
 
 func (f *textFormatter) printColored(b *bytes.Buffer, entry *logrus.Entry, keys []string) {
+	var prefixColor string
+	var suffixColor string
+
 	var levelColor int
 	switch entry.Level {
 	case logrus.DebugLevel:
@@ -89,7 +102,15 @@ func (f *textFormatter) printColored(b *bytes.Buffer, entry *logrus.Entry, keys 
 
 	levelText := strings.ToUpper(entry.Level.String())[0:4]
 
-	fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%s]", levelColor, levelText, entry.Time.Format(defaultTimestampFormat))
+	if runtime.GOOS != "windows" {
+		prefixColor = fmt.Sprintf("\x1b[%dm", levelColor)
+		suffixColor = fmt.Sprintf("\x1b[0m")
+	} else {
+		prefixColor = fmt.Sprintf("")
+		suffixColor = fmt.Sprintf("")
+	}
+
+	fmt.Fprintf(b, "%s%s%s [%s]", prefixColor, levelText, suffixColor, entry.Time.Format(defaultTimestampFormat))
 
 	if entry.Message != "" {
 		fmt.Fprintf(b, " %s", entry.Message)
@@ -97,7 +118,7 @@ func (f *textFormatter) printColored(b *bytes.Buffer, entry *logrus.Entry, keys 
 
 	for _, k := range keys {
 		v := entry.Data[k]
-		fmt.Fprintf(b, " \x1b[%dm%s\x1b[0m=", levelColor, k)
+		fmt.Fprintf(b, " %s%s%s=", prefixColor, k, suffixColor)
 		f.appendValue(b, v)
 	}
 }
@@ -119,7 +140,7 @@ func (f *textFormatter) needsQuoting(text string) bool {
 
 func (f *textFormatter) appendKeyValue(b *bytes.Buffer, key string, value interface{}) {
 	if b.Len() > 0 {
-		b.WriteByte(' ')
+		b.WriteByte('\t')
 	}
 	b.WriteString(key)
 	b.WriteByte('=')


### PR DESCRIPTION
Hi, 

I propose this changes to the formatter to work on windows.

I had some issues with the coloring in the console and in the files.

The changes are:
- If it's windows, it will omit the coloring, before this change, tha output was something like this:

`[36mINFO[0m[2019-03-05T11:16:21-07:00] / [36mcontent_type[0m=application/json [36mduration[0m=0s [36mhuman_size[0m="34 B" [36mmethod[0m=GET [36mparams[0m="{}" [36mpath[0m=/ [36mrender[0m=0s [36mrequest_id[0m=PKxPTifevd-YTAIrbAYVP [36msize[0m=34 [36mstatus[0m=200`

afeter the change, it shows like this:

`INFO [2019-03-05T11:38:19-07:00] / content_type=application/json duration=0s human_size="34 B" method=GET params="{}" path=/ render=0s request_id=HzJUmxXRas-iMCaPiIgDd size=34 status=200`

- Also I put the time when the output is a file, before the change was something like this:

`level=info msg="Starting application at 0.0.0.0:3000"`

after the change is somenthing like this:

`level=info	time="2019-03-05T11:18:52-07:00"	msg="Starting application at 0.0.0.0:3000"`

I also change the space between each key/value to a tab, because I had trouble to parse it in Excel and thought it will be easier to parse.

- When the output is a file and the OS is windows, if you read it with the notepad or something similar it expect that the end of line is CRLF, but it puts only the LF, so the text was not separate by lines.

Any comment will be appreciated.

Greeting
Arnulfo José
