### PR TITLE
Add entry.Time to log when isColored is false

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -61,6 +61,7 @@ func (f *textFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 		f.printColored(b, entry, keys)
 	} else {
 		f.appendKeyValue(b, "level", entry.Level.String())
+		f.appendKeyValue(b, "time", entry.Time.Format(defaultTimestampFormat))
 		if entry.Message != "" {
 			f.appendKeyValue(b, "msg", entry.Message)
 		}


### PR DESCRIPTION
Fixes https://github.com/gobuffalo/buffalo/issues/1658

Before:
`level=info msg="Starting application at 0.0.0.0:3000"`
After:
`level=info time="2019-07-01T00:12:01-06:00" msg="Starting application at 0.0.0.0:3000"`